### PR TITLE
Fixed shaders to use pointers, copies from Dict gave bad values

### DIFF
--- a/comp220-worksheetA/Camera.cpp
+++ b/comp220-worksheetA/Camera.cpp
@@ -18,20 +18,21 @@ glm::mat4 Camera::CalculateViewMatrix()
 void Camera::Strafe(glm::vec3 mov, float delta)
 {
 	pos += mov * rotation * delta;
-	View =glm::lookAt(pos, lookAt, cameraUp);
+	View = glm::lookAt(pos, lookAt, cameraUp);
 }
 
 void Camera::MouseMovement(int x, int y)
 {
+	
 	rotation = rotation * glm::angleAxis(x * 0.001f, globals::worldUp);
 	rotation = rotation * glm::angleAxis(y * 0.001f, cameraRight);
-
+	
 	cameraForward = globals::worldForward * rotation;
 	cameraUp = globals::worldUp * rotation;
 	cameraRight = globals::worldRight * rotation;
 
 	lookAt = pos + cameraForward;
-
+	
 	View = glm::lookAt(pos, lookAt, cameraUp);
 }
 

--- a/comp220-worksheetA/shader.cpp
+++ b/comp220-worksheetA/shader.cpp
@@ -189,11 +189,11 @@ void ShaderManager::LoadShaders(std::string ShaderName, const char * vertex_file
 	glDeleteShader(VertexShaderID);
 	glDeleteShader(FragmentShaderID);
 
-	Shader s;
-	s.setProgramID(ProgramID);
-	s.discoverUniforms();
+	Shader *s=new Shader();
+	s->setProgramID(ProgramID);
+	s->discoverUniforms();
 
-	ShaderDict.insert(std::pair<std::string, Shader>(ShaderName, s));
+	ShaderDict.insert(std::pair<std::string, Shader*>(ShaderName, s));
 }
 
 /*
@@ -205,7 +205,7 @@ GLuint ShaderManager::GetShader(std::string name)
 
 Shader * ShaderManager::GetShader(std::string name)
 {
-	return &ShaderDict[name];
+	return ShaderDict[name];
 }
 
 Shader::Shader()

--- a/comp220-worksheetA/shader.h
+++ b/comp220-worksheetA/shader.h
@@ -55,14 +55,15 @@ public:
 		auto shaderiter = ShaderDict.begin();
 		while (shaderiter != ShaderDict.end())
 		{
-			glDeleteProgram((*shaderiter).second.getProgramID());
+			glDeleteProgram((*shaderiter).second->getProgramID());
+			delete (*shaderiter).second;
 			shaderiter++;
 		};
 	};
 
 private:
 	//std::map<std::string, GLuint> ShaderDict;
-	std::map<std::string, Shader> ShaderDict;
+	std::map<std::string, Shader*> ShaderDict;
 
 };
 


### PR DESCRIPTION
Fixed this by storing pointers in the Shader manager map. The reason why this was failing is that we were returning copies rather than the actual shader objects in memory. 

Using pointers mean that we only have one copy of shader(which is store in the map)